### PR TITLE
docs: add get key permission requirement for Azure Key Vault when version is omitted

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -438,12 +438,18 @@ $ keyvault_name=sops-$(uuidgen | tr -d - | head -c 16)
 $ az keyvault create --name $keyvault_name --resource-group sops-rg --location westeurope
 $ az keyvault key create --name sops-key --vault-name $keyvault_name --protection software --ops encrypt decrypt
 $ az keyvault set-policy --name $keyvault_name --resource-group sops-rg --spn $AZURE_CLIENT_ID \
-    --key-permissions encrypt decrypt
+    --key-permissions get encrypt decrypt
 # Read the key id:
 $ az keyvault key show --name sops-key --vault-name $keyvault_name --query key.kid
 
 https://sops.vault.azure.net/keys/sops-key/some-string
 ```
+
+> 📝 **Note**
+>
+> The `get` key permission is required when the key version is ommited (for example if the URL ends with a trailing slash).
+> In that case SOPS calls the Azure Key Vault API to resolve the latest key version, which requires the `get` permission.
+> If you specifty an explicit key version in the URL you can omit `get`, but this means you will need to update your configuration every time the key is rotated.
 
 Now you can encrypt a file using:
 


### PR DESCRIPTION
Transfer of https://github.com/getsops/sops/pull/2122