### PR TITLE
Add info box that the current docs are a preview, depending on branch name / PR

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -181,6 +181,15 @@ params:
         icon: "fab fa-slack"
         desc: "Chat with other project developers"
 
+# Allow content to retrieve the PULL_REQUEST and BRANCH environment variables.
+# These are provided during Netlify builds:
+# https://docs.netlify.com/build/configure-builds/environment-variables/#git-metadata
+security:
+  funcs:
+    getenv:
+      - PULL_REQUEST
+      - BRANCH
+
 # hugo module configuration
 
 module:

--- a/layouts/_partials/version-banner.html
+++ b/layouts/_partials/version-banner.html
@@ -1,0 +1,18 @@
+{{- /* https://docs.netlify.com/build/configure-builds/environment-variables/#git-metadata */ -}}
+{{- $is_pr := getenv "PULL_REQUEST" -}}
+{{- $branch := getenv "BRANCH" -}}
+{{- if or (ne $is_pr "true") (ne $branch "stable") -}}
+  {{- $color := "primary" -}}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    <p>
+      {{- if eq $is_pr "true" -}}
+        This is a preview of a Pull Request for SOPS documentation.
+      {{- else if eq $branch "main" -}}
+        This is the development version of the SOPS documentation.
+      {{- else -}}
+        This is a preview of the SOPS documentation.
+      {{- end }}
+      The documentation for the latest SOPS release can be found on <a href="https://getsops.io/">getsops.io</a>.
+    </p>
+  </div>
+{{ end -}}


### PR DESCRIPTION
This unfortunately only works for actual doc pages, i.e. https://getsops.io/docs/ and https://getsops.io/docs/contribution-guidelines/. The Docsy theme is too inflexible to inject similar boxes anywhere else...